### PR TITLE
Fikser regex

### DIFF
--- a/patch-assembly-version.sh
+++ b/patch-assembly-version.sh
@@ -32,9 +32,9 @@ then
     baseVersionFourTuple=1.0.0.0
     nugetVersion=1.0.0.0-norelease 
     
-    print_versions ${baseVersionFourTuple} ${nugetVersion}
+    print_versions "${baseVersionFourTuple}" "${nugetVersion}"
 else
-    echo "Found tag ${tag}. Parsing ..."
+    echo "Found tag '${tag}'. Parsing ..."
     baseVersionFourTuple="$(echo ${tag} | grep -E -o '[0-9]+(\.[0-9]+){0,3}' | head -1)"
     nugetVersion="${tag}"
 

--- a/patch-assembly-version.sh
+++ b/patch-assembly-version.sh
@@ -17,7 +17,7 @@ function stop_if_no_assembly_version_found {
 function print_versions {
     assemblyVersion=$1
     nugetVersion=$2
-
+    
     echo "======================================================================"
 	echo " Assembly Version/.dll (AssemblyVersion): $assemblyVersion"
 	echo " Nuget version (Version): $nugetVersion"
@@ -34,10 +34,11 @@ then
     
     print_versions ${baseVersionFourTuple} ${nugetVersion}
 else
-    baseVersionFourTuple=$(echo ${tag} | egrep -o '([0-9].){3}([0-9])')
-    nugetVersion=${tag}
+    echo "Found tag ${tag}. Parsing ..."
+    baseVersionFourTuple="$(echo ${tag} | grep -E -o '[0-9]+(\.[0-9]+){0,3}' | head -1)"
+    nugetVersion="${tag}"
 
-    print_versions ${baseVersionFourTuple} ${nugetVersion}
+    print_versions "${baseVersionFourTuple}" "${nugetVersion}"
 fi
 
 if [ -z "$TRAVIS_BRANCH" ] # The two following cases are only different by gsed vs sed, please edit both at the same time

--- a/patch-assembly-version.sh
+++ b/patch-assembly-version.sh
@@ -35,7 +35,7 @@ then
     print_versions "${baseVersionFourTuple}" "${nugetVersion}"
 else
     echo "Found tag '${tag}'. Parsing ..."
-    baseVersionFourTuple="$(echo ${tag} | grep -E -o '[0-9]+(\.[0-9]+){0,3}' | head -1)"
+    baseVersionFourTuple="$(echo ${tag} | grep --extended-regexp --only-matching '[0-9]+(\.[0-9]+){0,3}' | head -1)"
     nugetVersion="${tag}"
 
     print_versions "${baseVersionFourTuple}" "${nugetVersion}"


### PR DESCRIPTION
Av en eller annen grunn har regex for uthenting av versjonsnummer gått litt skeis. Nå har vi gjort kommandoer tryggere ved å inkapsulere  i `""`, noe som gjør at parametere blir sendt som rett argument om den ene ikke finnes. Vi går også over til en enklere regex for uthenting og bruer extended versjon av grep (`grep -E`) i stedet for `egrep`, som er deprecated: 
```
In addition, the variant programs egrep, fgrep and rgrep are the same as grep -E, grep -F,
and grep -r, respectively.  These variants are deprecated, but are provided  for  backward
compatibility.

```
